### PR TITLE
Updated packageSourceUrl and fixed issue with ServerCertificateValidationCallback causing dependent packages to fail

### DIFF
--- a/jdk8/jdk8.nuspec
+++ b/jdk8/jdk8.nuspec
@@ -13,7 +13,7 @@
       changes:
       -8u92
     </releaseNotes>
-    <packageSourceUrl>https://chocolatey.org/packages/jdk8/</packageSourceUrl>
+    <packageSourceUrl>https://github.com/ootaken/chocolatey/tree/master/jdk8</packageSourceUrl>
     <description>By default this package installs JDK according to your platform (x86 or x64).
 
 If you want to install 32bits JDK on 64bits OS

--- a/jdk8/tools/common.ps1
+++ b/jdk8/tools/common.ps1
@@ -38,6 +38,7 @@ function download-from-oracle($url, $output_filename) {
         $client = New-Object Net.WebClient
         $dummy = $client.Headers.Add('Cookie', 'gpw_e24=http://www.oracle.com; oraclelicense=accept-securebackup-cookie')
         $dummy = $client.DownloadFile($url, $output_filename)
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $null
     }  
 }
 


### PR DESCRIPTION
FIXES: https://github.com/ootaken/chocolatey/issues/3
FIXES: https://github.com/ootaken/chocolatey/issues/2
